### PR TITLE
Allow the `module_inception` lint on any `#[routes]` annotated module…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,14 +799,14 @@ dependencies = [
 
 [[package]]
 name = "leptos-routes"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leptos-routes-macro",
 ]
 
 [[package]]
 name = "leptos-routes-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assertr",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,15 @@ resolver = "2"
 members = ["leptos-routes", "leptos-routes-macro"]
 default-members = ["leptos-routes"]
 
+[workspace.package]
+version = "0.3.1"
+edition = "2024"
+rust-version = "1.85.0"
+authors = ["Lukas Potthast <privat@lukas-potthast.de>"]
+repository = "https://github.com/lpotthast/leptos-routes"
+license = "MIT OR Apache-2.0"
+readme = "./README.md"
+
 [workspace.dependencies]
 proc-macro2 = "1.0.92"
 quote = "1.0.38"

--- a/leptos-routes-macro/Cargo.toml
+++ b/leptos-routes-macro/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "leptos-routes-macro"
-version = "0.3.0"
-edition = "2024"
-rust-version = "1.85.0"
-authors = ["Lukas Potthast <privat@lukas-potthast.de>"]
-license = "MIT OR Apache-2.0"
-readme = "../README.md"
-repository = "https://github.com/lpotthast/leptos-routes"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 description = """
 Proc macro deriving route structs for the leptos-routes crate.
 """

--- a/leptos-routes/Cargo.toml
+++ b/leptos-routes/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "leptos-routes"
-version = "0.3.0"
-edition = "2024"
-rust-version = "1.85.0"
-authors = ["Lukas Potthast <privat@lukas-potthast.de>"]
-license = "MIT OR Apache-2.0"
-readme = "../README.md"
-repository = "https://github.com/lpotthast/leptos-routes"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 description = """
 Fluent route declarations for the Leptos web framework.
 """


### PR DESCRIPTION
…, allowing an inline `routes` mod to be placed in a `routes.rs` without experiencing clippy warnings